### PR TITLE
WIE-39/Smaller Event Carousel

### DIFF
--- a/components/Carousel/Carousel.tsx
+++ b/components/Carousel/Carousel.tsx
@@ -33,7 +33,7 @@ export default function Carousel ({slides, options, size} : CarouselProps) {
   const { selectedIndex, scrollSnaps, onDotButtonClick } = useDotButton(emblaApi, onNavButtonClick)
   
   return (
-    <Box mx={5} mt={2} mb={6} justifyContent='center'>
+    <Box mx={5} mb={6} justifyContent='center'>
       <Stack direction='row' sx={{justifyContent: 'center', alignItems: 'center'}}>
         <CarouselArrowButton type='prev' onButtonClick={onPrevButtonClick}/>
         <Box ref={emblaRef} sx={{overflow: 'hidden'}} width={{xs: '100%', sm: '90%', md: '80%', lg: '70%', xl: '60%'}}>
@@ -48,7 +48,7 @@ export default function Carousel ({slides, options, size} : CarouselProps) {
               key={index}
                 mr={2}
                 sx={{flex: size == 'large'
-                    ? {xs: '0 0 300px', sm: '0 0 400px', md: '0 0 500px', lg: '0 0 600px'}
+                    ? {xs: '0 0 300px', sm: '0 0 400px'}
                     : '0 0 300px'
                 }}>
                 <EventsCard key={index}/>


### PR DESCRIPTION
Made event cards smaller in carousel on landing page

<img width="1431" alt="Screen Shot 2024-07-05 at 9 19 27 am" src="https://github.com/UNSW-WIESoc/website/assets/79835146/f7a9f91c-4711-4020-bdef-d887c7a6a70b">
