### PR TITLE
WIE-28/page-header-mobile-responsiveness

### DIFF
--- a/components/PageHeaderCard.tsx
+++ b/components/PageHeaderCard.tsx
@@ -1,43 +1,69 @@
-import {AspectRatio, Box, Stack, Typography} from '@mui/joy';
+import { AspectRatio, Box, Stack, Typography } from '@mui/joy';
 import Image from 'next/image';
-
 
 interface PageHeaderCardProps {
   imagePath: string;
   pageTitle: string;
 }
-export default function PageHeaderCard({imagePath, pageTitle} : PageHeaderCardProps) {
+
+export default function PageHeaderCard({ imagePath, pageTitle }: PageHeaderCardProps) {
   return (
-      <AspectRatio ratio='700/150' objectFit='cover'
-                   sx={{width: '100%', height: '300px', position: 'relative', overflow:'hidden'}}>
-        <Image src={imagePath} alt='page-header-image' fill/>
-        <Box
-          className='bg-dark-blue'
+    <AspectRatio
+      ratio="700/150"
+      objectFit="cover"
+      sx={{
+        width: '100%',
+        height: {
+          xs: '200px',
+          sm: '250px',
+          md: '300px',
+          lg: '350px',
+          xl: '400px',
+        },
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <Image src={imagePath} alt="page-header-image" fill />
+      <Box
+        className="bg-dark-blue"
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          opacity: '0.6',
+        }}
+      />
+      <Stack
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+        }}
+        alignItems="center"
+        justifyContent="center"
+        spacing={2}
+      >
+        <Typography
+          level="title"
+          className="light-white"
           sx={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '300px',
-            opacity: '0.6',
+            fontSize: {
+              xs: '1.5rem',
+              sm: '2rem',
+              md: '2.5rem',
+              lg: '3rem',
+              xl: '3.5rem',
+            },
           }}
-        />
-        <Stack
-          sx={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '300px',
-          }}
-          alignItems='center'
-          justifyContent='center'
-          spacing={8}
         >
-          <Typography level='title' className='light-white'>
-            {pageTitle}
-          </Typography>
-        </Stack>
-      </AspectRatio>
-  )
+          {pageTitle}
+        </Typography>
+      </Stack>
+    </AspectRatio>
+  );
 }

--- a/components/PageHeaderCard.tsx
+++ b/components/PageHeaderCard.tsx
@@ -9,17 +9,11 @@ interface PageHeaderCardProps {
 export default function PageHeaderCard({ imagePath, pageTitle }: PageHeaderCardProps) {
   return (
     <AspectRatio
-      ratio="700/150"
+      ratio="650/150"
       objectFit="cover"
       sx={{
         width: '100%',
-        height: {
-          xs: '200px',
-          sm: '250px',
-          md: '300px',
-          lg: '350px',
-          xl: '400px',
-        },
+        height: 'auto',
         position: 'relative',
         overflow: 'hidden',
       }}


### PR DESCRIPTION
Added page header card mobile responsiveness 

<img width="504" alt="Screenshot 2024-07-18 at 5 50 41 am" src="https://github.com/user-attachments/assets/56a9831f-c210-4878-90ef-c6cac032aaef">
<img width="1247" alt="Screenshot 2024-07-18 at 5 50 31 am" src="https://github.com/user-attachments/assets/a0781d93-c06e-449c-8db6-f84c087c083b">
<img width="768" alt="Screenshot 2024-07-18 at 5 50 18 am" src="https://github.com/user-attachments/assets/c4000231-94df-4292-8918-616571a16aa6">
