### PR TITLE
Wie 47/remove carousel if no events

### DIFF
--- a/app/(pages)/events/page.tsx
+++ b/app/(pages)/events/page.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 import EventsCard from '@/components/EventsCard';
 
-import {Grid, Stack, Box} from '@mui/joy';
+import {Grid, Stack, Box, Typography} from '@mui/joy';
 import PageHeaderCard from '@/components/PageHeaderCard';
 import HeadingBodyText from '@/components/HeadingBodyText';
 import EventsCarousel from '@/components/Carousel/EventsCarousel';
@@ -34,30 +34,41 @@ export default function Events() {
       <PageHeaderCard imagePath={'/events/header.jpg'} pageTitle={'Events'}/>
       <HeadingBodyText heading='Upcoming Events' body='WIESoc hold many events throughout the year, with a great mix of industry
         and social events. Come and join us for our upcoming events!' color='graphite'/>
-      <Grid
-        container
-        justifyContent='center'
-        sx={{ 'width': {xs: '100%', sm: '90%', md: '80%', lg: '70%', xl: '60%'} }}
-        spacing={10}
-        mb={10}
-      >
-        {upcomingEvents && upcomingEvents?.map((event: any, index: number) => (
-          <Grid
-            xs={12} sm={12} md={6}
-            key={index}
-            display='flex'
-            justifyContent='center'
-            alignItems='center'
-          >
-            <Box flexGrow={1} justifyContent='center'>
-              <EventsCard
-                key={index}
-                event={event}
-              />
-            </Box>
-          </Grid>
-        ))}
-      </Grid>
+      {upcomingEvents.length > 0 ? (
+        <Grid
+          container
+          justifyContent='center'
+          sx={{ 'width': {xs: '100%', sm: '90%', md: '80%', lg: '70%', xl: '60%'} }}
+          spacing={10}
+          mb={10}
+        >
+          {upcomingEvents && upcomingEvents?.map((event: any, index: number) => (
+            <Grid
+              xs={12} sm={12} md={6}
+              key={index}
+              display='flex'
+              justifyContent='center'
+              alignItems='center'
+            >
+              <Box flexGrow={1} justifyContent='center'>
+                <EventsCard
+                  key={index}
+                  event={event}
+                />
+              </Box>
+            </Grid>
+          ))}
+        </Grid>
+      ) : (
+        <Typography level='body' textAlign='center' px={3}
+        sx={{
+          textWrap: 'wrap',
+          paddingBottom: '80px',
+          fontStyle: 'italic'
+        }}>
+          No upcoming events currently, check back later!
+        </Typography>
+      )}
       
       <EventsCarousel heading='Past Events' body='WIESoc hold many events throughout the semester, with a great mix of industry and social events.
 Browse our previous events over the past year!' slides={pastEvents} size='small'/>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -191,11 +191,15 @@ export default function Home() {
   }, []);
   
   const eventsCarouselText = 'WIESoc hold many events throughout the semester, with a great mix of industry and social events.\nCome and join us for our upcoming events!';
+
   return (
     <Box justifyContent='center'>
       <CoverImage/>
       <AboutUsOverview />
       <SponsorsPreview />
+      {/* {upcomingEvents.length > 0  && (
+        <EventsCarousel heading='Upcoming Events' body={eventsCarouselText} slides={upcomingEvents} size='large'/>
+      )} */}
       <EventsCarousel heading='Upcoming Events' body={eventsCarouselText} slides={upcomingEvents} size='large'/>
       <ProgramsOverview/>
     </Box>

--- a/components/Carousel/EventsCarousel.tsx
+++ b/components/Carousel/EventsCarousel.tsx
@@ -25,10 +25,11 @@ export default function EventsCarousel({heading, body, slides, size} : EventsCar
         <Carousel slides={slides} options={OPTIONS} size={size} />
       )}
       {slides.length == 0 && (
-        <Typography className='dark-blue' level='body' textAlign='center' px={3} 
+        <Typography level='body' textAlign='center' px={3} 
         sx={{
           textWrap: 'wrap',
-          paddingBottom: '30px'
+          paddingBottom: '80px',
+          fontStyle: 'italic'
         }}>
           No upcoming events currently, check back later!
         </Typography>

--- a/components/Carousel/EventsCarousel.tsx
+++ b/components/Carousel/EventsCarousel.tsx
@@ -1,6 +1,6 @@
 import HeadingBodyText from '@/components/HeadingBodyText';
 import Carousel from './Carousel';
-import { Box } from '@mui/joy';
+import { Box, Typography } from '@mui/joy';
 
 interface EventsCarouselProps {
   heading: string;
@@ -21,7 +21,18 @@ export default function EventsCarousel({heading, body, slides, size} : EventsCar
   return (
     <Box className='bg-medium-blue' sx={{justifyContent: 'center'}} pb={3} width='100%'>
       <HeadingBodyText heading={heading} body={body} color='light-white'/>
-      <Carousel slides={slides} options={OPTIONS} size={size} />
+      {slides.length > 0 && (
+        <Carousel slides={slides} options={OPTIONS} size={size} />
+      )}
+      {slides.length == 0 && (
+        <Typography className='dark-blue' level='body' textAlign='center' px={3} 
+        sx={{
+          textWrap: 'wrap',
+          paddingBottom: '30px'
+        }}>
+          No upcoming events currently, check back later!
+        </Typography>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
- If there are no upcoming events, the carousel on Home page is removed and a message saying check back later is shown
- Same for the Events page 

<img width="525" alt="image" src="https://github.com/user-attachments/assets/971451f6-0f32-4d61-b7c2-f215de0eaa6e">
