### PR TITLE
fixed mobile navbar disappearing when page scrolled up at the top of …

### DIFF
--- a/components/MobileNavBar.tsx
+++ b/components/MobileNavBar.tsx
@@ -21,7 +21,9 @@ const NavBar = () => {
     const handleScroll = () => {
       const currentScrollY = window.scrollY;
 
-      if (currentScrollY > lastScrollY.current) {
+      if (currentScrollY < 40) {
+        setVisible(true);
+      } else if (currentScrollY > lastScrollY.current) {
         // scrolling down
         setVisible(false);
       } else {

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -138,7 +138,9 @@ export default function NavBar() {
     const handleScroll = () => {
       const currentScrollY = window.scrollY;
 
-      if (currentScrollY > lastScrollY.current) {
+      if (currentScrollY < 40) {
+        setVisible(true);
+      } else if (currentScrollY > lastScrollY.current) {
         // scrolling down
         setVisible(false);
       } else {


### PR DESCRIPTION
Added 40px restriction for navbar disappearing at the top of the page to prevent navbar disappearing due to bounce when scrolled up at the top